### PR TITLE
ArcPacker.cs: Special case for compressing a zero-byte file.

### DIFF
--- a/Sonic-06-Toolkit/src/Sonic-06-Toolkit/ArcPacker.cs
+++ b/Sonic-06-Toolkit/src/Sonic-06-Toolkit/ArcPacker.cs
@@ -282,9 +282,22 @@ namespace Toolkit.Tools
                             // Write the zlib header.
                             fs.Write(zlibHeader, 0, zlibHeader.Length);
 
-                            // Write the compressed data.
-                            memStream.Seek(0, SeekOrigin.Begin);
-                            memStream.CopyTo(fs);
+                            // Compressed size, plus 6 for zlib header and Adler-32 checksum.
+                            node.compressed_size = (uint)memStream.Length + 6;
+
+                            if (memStream.Length != 0)
+                            {
+                                // Write the compressed data.
+                                memStream.Seek(0, SeekOrigin.Begin);
+                                memStream.CopyTo(fs);
+                            }
+                            else
+                            {
+                                // Special case: Zero-length file needs an extra '\x03' byte.
+                                byte[] b_extra03 = new byte[] { 0x03 };
+                                fs.Write(b_extra03, 0, b_extra03.Length);
+                                node.compressed_size++;
+                            }
 
                             // Write the Adler-32 checksum.
                             byte[] b_adler32 = BitConverter.GetBytes(adler32);
@@ -293,9 +306,6 @@ namespace Toolkit.Tools
                                 Array.Reverse(b_adler32);
                             }
                             fs.Write(b_adler32, 0, b_adler32.Length);
-
-                            // Compressed size, plus 6 for zlib header and Adler-32 checksum.
-                            node.compressed_size = (uint)memStream.Length + 6;
                         }
                         fs_src.Close();
 

--- a/Sonic-06-Toolkit/src/Sonic-06-Toolkit/ArcPacker.cs
+++ b/Sonic-06-Toolkit/src/Sonic-06-Toolkit/ArcPacker.cs
@@ -285,7 +285,7 @@ namespace Toolkit.Tools
                             // Compressed size, plus 6 for zlib header and Adler-32 checksum.
                             node.compressed_size = (uint)memStream.Length + 6;
 
-                            if (memStream.Length != 0)
+                            if (memStream.Length > 0)
                             {
                                 // Write the compressed data.
                                 memStream.Seek(0, SeekOrigin.Begin);

--- a/Sonic-06-Toolkit/src/Sonic-06-Toolkit/ArcPacker.cs
+++ b/Sonic-06-Toolkit/src/Sonic-06-Toolkit/ArcPacker.cs
@@ -293,10 +293,11 @@ namespace Toolkit.Tools
                             }
                             else
                             {
-                                // Special case: Zero-length file needs an extra '\x03' byte.
-                                byte[] b_extra03 = new byte[] { 0x03 };
+                                // Special case: Zero-length file needs "\x03\x00" in order to
+                                // not be misdetected as uncompressed.
+                                byte[] b_extra03 = new byte[] { 0x03, 0x00 };
                                 fs.Write(b_extra03, 0, b_extra03.Length);
-                                node.compressed_size++;
+                                node.compressed_size += b_extra03.Length;
                             }
 
                             // Write the Adler-32 checksum.


### PR DESCRIPTION
We need to add an extra '\x03' byte.